### PR TITLE
Add mkwrs.com.xml

### DIFF
--- a/src/chrome/content/rules/mkwrs.com.xml
+++ b/src/chrome/content/rules/mkwrs.com.xml
@@ -1,0 +1,7 @@
+<ruleset name="MKWRs">
+        <target host="mkwrs.com" />
+        <target host="www.mkwrs.com" />
+
+        <rule from="^http:"
+                to="https:" />
+</ruleset>


### PR DESCRIPTION
mkwrs.com tracks the world record time trials for every game in the _Mario Kart_ video game series. This adds a rule-set to convert HTTP requests to HTTPS links.